### PR TITLE
Remove htmlentities and utf8_encode

### DIFF
--- a/src/Bluem.php
+++ b/src/Bluem.php
@@ -219,7 +219,7 @@ class Bluem {
         $validator = new BluemXMLValidator();
         if ( ! $validator->validate(
             $transaction_request->RequestContext(),
-            utf8_encode( $transaction_request->XmlString() )
+            $transaction_request->XmlString()
         )
         ) {
             return new ErrorBluemResponse(
@@ -262,10 +262,10 @@ class Bluem {
             echo PHP_EOL . "<BR>HEADER// " . 'x-ttrs-files-count: ' . '1';
             echo PHP_EOL . "<BR>HEADER// " . 'x-ttrs-filename: ' . $xttrs_filename;
             echo "<HR>";
-            echo PHP_EOL . "BODY: " . utf8_encode( $transaction_request->XmlString() );
+            echo PHP_EOL . "BODY: " . $transaction_request->XmlString();
         }
 
-        $req->setBody( utf8_encode( $transaction_request->XmlString() ) );
+        $req->setBody( $transaction_request->XmlString() );
         try {
             $http_response = $req->send();
             if ( self::$verbose ) {

--- a/src/Requests/IBANBluemRequest.php
+++ b/src/Requests/IBANBluemRequest.php
@@ -53,7 +53,7 @@ class IBANBluemRequest extends BluemRequest implements BluemRequestInterface {
      */
     private function _sanitizeIban( string $iban ): string {
         return trim(
-            str_replace( ' ', '', htmlentities( $iban ) )
+            str_replace( ' ', '', $iban )
         );
     }
 
@@ -65,9 +65,7 @@ class IBANBluemRequest extends BluemRequest implements BluemRequestInterface {
      * @return string
      */
     private function _sanitizeName( string $name ): string {
-        return trim(
-            htmlentities( $name )
-        );
+        return trim( $name );
     }
 
     /**


### PR DESCRIPTION
Removing htmlentities sanitize and removed utf8 encode to fix: https://github.com/bluem-development/bluem-php/issues/24